### PR TITLE
Update ZMQ dependency to fix compilation on Node 5.x and greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lodash": "^4.5.1",
     "msgpack-js": "~0.3.0",
     "uuid": "~2.0.1",
-    "zmq": "2.14.x",
+    "zmq": "2.15.x",
     "zmq-service-suite-message": "0.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
See ZMQ issue https://github.com/JustinTulloss/zeromq.node/pull/520 for
more background context.

TLDR: NaN versions before 2.2.0 are not compatible with NodeJS 5.x and
greater.  The issue cited above was closed on April 26th, making 2.15.0
the first release of the node ZMQ bindings that can compile on Node releases
5.x and beyond.

The latest release of the zmq-service-suite libraries have a dependency
declared on zmq 2.14.x, so they are also incompatible with node 5.x and
beyond.

This PR updates the dependency from 2.14.x to 2.15.x, which currently picks
up relese 2.15.3 of zmq.  After making this single change I'm able to compile
and install this package on MacOSX 10.12.2, running either NodeJS v6.9.5 or
NodeJS v6.10.0.  Other versions should be compatible as well--these are the
only two I've got in use and so the only two I experimented with.