### PR TITLE
add basic token authentication

### DIFF
--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -74,6 +74,9 @@ var Frontend = function(configuration, smiService){
 
       var from = frames[IDENTITY_FRAME];
       var rid = frames[RID_FRAME];
+      var headers = msgpack.decode(frames[HEADERS_FRAME]);
+
+      console.log(headers);
 
       log.info("received rid: %s from: %s", rid, from);
 
@@ -83,7 +86,7 @@ var Frontend = function(configuration, smiService){
       // }
 
       // valid client identity
-      if(!from){
+      if(!from || (config.token && config.token != headers.token)){
         log.error("received message without client identity for rid:", rid);
         msg = Message.parse(frames);
         replyError(500, msg);

--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -76,8 +76,6 @@ var Frontend = function(configuration, smiService){
       var rid = frames[RID_FRAME];
       var headers = msgpack.decode(frames[HEADERS_FRAME]);
 
-      console.log(headers);
-
       log.info("received rid: %s from: %s", rid, from);
 
       // TODO: log frames in debug mode
@@ -86,7 +84,7 @@ var Frontend = function(configuration, smiService){
       // }
 
       // valid client identity
-      if(!from || (config.token && config.token != headers.token)){
+      if(!from || (config.token && config.token !== headers.token)){
         log.error("received message without client identity for rid:", rid);
         msg = Message.parse(frames);
         replyError(500, msg);

--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -20,7 +20,8 @@ var Frontend = function(configuration, smiService){
   var log = Logger.getLogger('Frontend');
 
   var defaults = {
-    frontend: 'tcp://127.0.0.1:5560'
+    frontend: 'tcp://127.0.0.1:5560',
+    token: null
   };
 
   var config = _.defaults(configuration, defaults);
@@ -77,6 +78,7 @@ var Frontend = function(configuration, smiService){
       var headers = msgpack.decode(frames[HEADERS_FRAME]);
 
       log.info("received rid: %s from: %s", rid, from);
+      console.log(headers);
 
       // TODO: log frames in debug mode
       // if (log.isDebug()) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zmq-service-suite-broker",
+  "name": "zmq-service-suite-broker-tokenized",
   "version": "0.1.3",
   "description": "0MQ Service oriented Suite - Broker",
   "main": "index.js",
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/micro-toolkit/zmq-service-suite-broker-js.git"
+    "url": "git://github.com/ISEngineering/zmq-service-suite-broker-js.git"
   },
   "keywords": [
     "0MQ",
     "ZeroMQ",
     "SOA",
     "microservices",
-    "micro-toolkit"
+    "ISEngineering"
   ],
   "author": {
     "name": "Pedro Januário",
@@ -26,9 +26,9 @@
   "contributors": [],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/micro-toolkit/zmq-service-suite-broker-js/issues"
+    "url": "https://github.com/ISEngineering/zmq-service-suite-broker-js/issues"
   },
-  "homepage": "https://github.com/micro-toolkit/zmq-service-suite-broker-js",
+  "homepage": "https://github.com/ISEngineering/zmq-service-suite-broker-js",
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-bump": "0.8.0",

--- a/spec/unit/frontend_spec.js
+++ b/spec/unit/frontend_spec.js
@@ -98,14 +98,14 @@ describe('Frontend', function(){
         var validToken = "v4l1d0k3n";
 
         beforeEach(function() {
-          var tokenConfig = _.merge({ token: validToken }, config)
+          var tokenConfig = _.merge({ token: validToken }, config);
           
           target = new Frontend(tokenConfig, smi);
         });
 
         describe('invalid token', function(){
           it('returns status 500', function(done){
-            frames[HEADERS_FRAME] = msgpack.encode({ token: 'abc '})
+            frames[HEADERS_FRAME] = msgpack.encode({ token: 'abc '});
 
             socketMock.on = function(type, callback){
               if(type === 'message'){
@@ -125,7 +125,7 @@ describe('Frontend', function(){
         });
 
         describe('valid token', function(){
-          it('should carry on', function() {
+          it('should carry on', function(done) {
             frames[HEADERS_FRAME] = msgpack.encode({ token: validToken });
 
             socketMock.on = function(type, callback){

--- a/spec/unit/frontend_spec.js
+++ b/spec/unit/frontend_spec.js
@@ -5,7 +5,8 @@ describe('Frontend', function(){
       zmq = require('zmq'),
       msgpack = require('msgpack-js'),
       Frontend = require('../../lib/frontend'),
-      SMI = require('../../lib/smi');
+      SMI = require('../../lib/smi'),
+      _ = require('lodash');
 
 
   var IDENTITY_FRAME = 0,
@@ -92,6 +93,59 @@ describe('Frontend', function(){
           msgpack.encode("data")
         ];
       });
+
+      describe('protected with token', function(){
+        var validToken = "v4l1d0k3n";
+
+        beforeEach(function() {
+          var tokenConfig = _.merge({ token: validToken }, config)
+          
+          target = new Frontend(tokenConfig, smi);
+        });
+
+        describe('invalid token', function(){
+          it('returns status 500', function(done){
+            frames[HEADERS_FRAME] = msgpack.encode({ token: 'abc '})
+
+            socketMock.on = function(type, callback){
+              if(type === 'message'){
+                callback.apply(null, frames);
+              }
+            };
+
+            socketMock.send = function(frames){
+              expect(frames[STATUS_FRAME]).toBe(500);
+              done();
+            };
+
+            spyOn(zmq, 'socket').andReturn(socketMock);
+
+            target.run();
+          });
+        });
+
+        describe('valid token', function(){
+          it('should carry on', function() {
+            frames[HEADERS_FRAME] = msgpack.encode({ token: validToken });
+
+            socketMock.on = function(type, callback){
+              if(type === 'message'){
+                callback.apply(null, frames);
+              }
+            };
+    
+            socketMock.send = function(frames){
+              expect(frames[STATUS_FRAME]).not.toBe(500);
+              done();
+            };
+
+            spyOn(zmq, 'socket').andReturn(socketMock);
+
+            target.run();
+          });
+        });
+      });
+
       describe('with error', function(){
 
         describe('on zmq error', function(){


### PR DESCRIPTION
This adds basic token authentication.

Sometimes I need to expose broker service to network and this gives us basic access restriction.

broker config:
```
{
...
frontend: ''tcp://0.0.0.0:7777",
token: "some_random_md5_hash_or_whatever_works_for_you",
...
}
```

client:
```ruby
client.call(:VERB, data, headers: { token: "some_random_md5_hash_or_whatever_works_for_you" })
```